### PR TITLE
Add Quick Find support for sorting by Level

### DIFF
--- a/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/QuickInventory/Client.lua
+++ b/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/QuickInventory/Client.lua
@@ -100,6 +100,11 @@ local QuickInventory = {
            Text = "Quick Swap...",
            ContextDescription = "Context menu button label",
         },
+        Setting_Sorting_Name = {
+            Handle = "h39395b76g0d38g4e2egb0e8ga740cc618466",
+            Text = "Sorting",
+            ContextDescription = "Sorting select label",
+        },
     },
 
     USE_LEGACY_EVENTS = false,


### PR DESCRIPTION
- [x] add a quick find select for sorting by rarity (existing behavior) or level (new)
- [x] secondary sort by the other setting, which should generally be strictly better than random
  - in testing this felt really really intuitive and useful
- [x] split sorting logic up to simple scoring functions, and logic to turn that into industry-standard comparison ints (-1, 0, and 1)

default is sort by rarity (existing)
![image](https://github.com/user-attachments/assets/f526a7e8-9901-4114-8bd1-67132dd49f7b)

however a tie in greenfalls back on level (non-wands are level 2)
![image](https://github.com/user-attachments/assets/57fb5c28-c2d5-41e3-a7e3-1fbcc6bf34ad)

sort by level is as expected (then by rarity for all these level 2 items)
![image](https://github.com/user-attachments/assets/dbcb5be6-237d-49b9-a0bc-5abb709c430d)
