### PR TITLE
Vanity Transmog: generate templates at runtime, clean up names

### DIFF
--- a/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/Vanity/Shared.lua
+++ b/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/Vanity/Shared.lua
@@ -377,12 +377,11 @@ local TSK = Vanity.TranslatedStrings
 ---@field Slots table<string, boolean>
 
 ---@class VanityTemplate
----@field GUID GUID
----@field Tags table<string, boolean>
 ---@field Name string
----@field Slot string
+---@field GUID GUID
 ---@field Mod GUID
----@field RootName string
+---@field Slot string
+---@field Tags set<string>
 ---@field Visuals GUID[]
 
 ---@class Features.Vanity.SaveData

--- a/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/Vanity/Transmog/Client.lua
+++ b/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/Vanity/Transmog/Client.lua
@@ -147,7 +147,7 @@ function Transmog.RegisterTemplate(entry)
         local modData = Ext.Mod.GetMod(modFolder)
         local modName = modData and modData.Info.Name or modFolder -- The GetMod() calls fails with the Shared module.
         Vanity.CATEGORIES[modFolder] = {
-            Name = modName,
+            Name = Transmog.MOD_NAME_REMAP[modFolder] or modName, -- Apply remaps for mods without user-friendly names.
             Mod = modFolder,
             Tags = {[modFolder] = true},
             ID = modFolder,
@@ -726,7 +726,7 @@ Transmog.Hooks.GetTemplateName:Subscribe(function(ev)
     local data = ev.TemplateEntry
     local name = data.Name
 
-    -- Miscellaneous prefix removals
+    -- Miscellaneous pattern replacements
     for pattern,replacement in pairs(Vanity.ROOT_NAME_REPLACEMENTS) do
         name = name:gsub(pattern, replacement)
     end

--- a/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/Vanity/Transmog/Shared.lua
+++ b/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/Epip/Vanity/Transmog/Shared.lua
@@ -33,6 +33,11 @@ local Transmog = {
         ---@diagnostic enable: undefined-field
     },
 
+    -- Maps mod folder names to user-friendly display names.
+    MOD_NAME_REMAP = {
+        ["ArmorSets"] = "Armor Sets",
+    },
+
     favoritedTemplates = {}, ---@type set<GUID.ItemTemplate>
     activeCharacterTemplates = {},
 

--- a/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/UI/Vanity/Vanity.lua
+++ b/Mods/EpipEncounters_7d32cb52-1cfd-4526-9b84-db4867bf9356/Story/RawFiles/Lua/UI/Vanity/Vanity.lua
@@ -268,9 +268,11 @@ local Vanity = {
         Shield = 7,
     },
 
-    -- Patterns to replace within root template names
-    -- to create a display name.
+    -- Patterns to replace within template names.
+    -- Applied *before* running the default `GetTemplateName` hook.
+    ---@type table<pattern, string>
     ROOT_NAME_REPLACEMENTS = {
+        -- Technical prefixes
         ["EQ_Armor"] = "",
         ["EQ_"] = "",
         ["Elves"] = "Elven",
@@ -281,6 +283,14 @@ local Vanity = {
         ["Clothing_"] = "",
         ["Maj_"] = "",
         ["ARM_UNIQUE_ARX"] = "", -- Fuck this one, screws the pascalcase pattern
+        ["^UNI_"] = "", -- "Unique"
+        ["^RC_"] = "", -- "Reaper's Coast"
+        ["^AMER_UNI_"] = "", -- EE Artifacts.
+        ["^AMER_ORI_"] = "", -- Uniques added by EE Origins.
+        ["^ARM_SETS_"] = "", -- "Armor Set"
+        ["^REF_"] = "", -- Reference models.
+        ["^LOOT_"] = "",
+        ["^S_"] = "", -- No idea what this prefix could stand for. Found on some FTJ items.
 
         -- Actual keywords
         ["Upperbody"] = "Chest",


### PR DESCRIPTION
The rest of the Vanity rework is far from done but these changes are useful enough by their own that they warrant being shipped in the 5th anniversary patch.